### PR TITLE
Handle sharp curves

### DIFF
--- a/src/meshline.glsl.js
+++ b/src/meshline.glsl.js
@@ -48,22 +48,29 @@ ShaderChunk['meshline_vert'] = /*glsl*/ `
 	    float w = lineWidth * width;
 	
 	    vec2 dir;
-	    if( nextP == currentP ) dir = normalize( currentP - prevP );
-	    else if( prevP == currentP ) dir = normalize( nextP - currentP );
-	    else {
+	    vec4 normal;
+	    if( nextP == currentP ) {
+	      dir = normalize( currentP - prevP );
+	      normal = vec4( -dir.y, dir.x, 0., 1. );
+	      normal.xy *= .5 * w;
+	    } else if( prevP == currentP ) {
+	      dir = normalize( nextP - currentP );
+	      normal = vec4( -dir.y, dir.x, 0., 1. );
+	      normal.xy *= .5 * w;
+	    } else {
 	        vec2 dir1 = normalize( currentP - prevP );
 	        vec2 dir2 = normalize( nextP - currentP );
 	        dir = normalize( dir1 + dir2 );
-	
+	        normal = vec4( -dir.y, dir.x, 0., 1. );
+
 	        vec2 perp = vec2( -dir1.y, dir1.x );
 	        vec2 miter = vec2( -dir.y, dir.x );
+	        float d = .5 * w / dot( perp, miter );
 	        //w = clamp( w / dot( miter, perp ), 0., 4. * lineWidth * width );
-	
+	        normal.xy *= d;
 	    }
 	
 	    //vec2 normal = ( cross( vec3( dir, 0. ), vec3( 0., 0., 1. ) ) ).xy;
-	    vec4 normal = vec4( -dir.y, dir.x, 0., 1. );
-	    normal.xy *= .5 * w;
 	    normal *= projectionMatrix;
 	    if( sizeAttenuation == 0. ) {
 	        normal.xy *= finalPosition.w;


### PR DESCRIPTION
Shader Change

The old shaders don’t handle sharp curves well.
<img width="743" alt="Pasted Graphic 1" src="https://github.com/lume/three-meshline/assets/43117506/9a9fc439-5c94-46ea-91d2-930fee4922d4">

The problem is that [the vertices that determine the sides of the line are always extruded by half of the line’s width, regardless of curvature](https://github.com/lume/three-meshline/blob/main/src/meshline.glsl.js#L66).

```
vec4 normal = vec4( -dir.y, dir.x, 0., 1. );
normal.xy *= .5 * w;
normal *= projectionMatrix;
```

This is an approximation that becomes worse and worse the more the line curves.
<img width="423" alt="Pasted Graphic 1" src="https://github.com/lume/three-meshline/assets/43117506/3cb03710-29a6-49ea-a321-d06fcae22a70">

The exact length of the normal vector is `0.5 * w / dot(perp, miter)`, where miter is the unit vector with the same direction as the normal vector.
<img width="196" alt="Pasted Graphic 2" src="https://github.com/lume/three-meshline/assets/43117506/cda81ac1-1d46-4984-b940-c8087619751d">

And the result looks much more natural.
<img width="707" alt="Pasted Graphic 3" src="https://github.com/lume/three-meshline/assets/43117506/41e6f04e-2305-407e-a88b-6b98b2b58ddf">
