### PR TITLE
Fix shader ERROR: 0:155: 'isPerspectiveMatrix' : no matching overloaded function found

### DIFF
--- a/src/meshline.glsl.js
+++ b/src/meshline.glsl.js
@@ -1,6 +1,7 @@
 import {ShaderChunk} from 'three'
 
 ShaderChunk['meshline_vert'] = /*glsl*/ `
+	#include <common>
 	${ShaderChunk.logdepthbuf_pars_vertex}
 	${ShaderChunk.fog_pars_vertex}
 	


### PR DESCRIPTION
Fixes #14.

See related issue above. 

I am not sure why, but I was only able to reproduce the problem in a larger project of ours where we use a lot of typescript files with Three.JS + esbuild. I tried to reproduce in a small test Three.js project with typescript and esbuild but I could not reproduce it...

Either way, I found the following OLD GH issue on the original MeshLine project for this very issue https://github.com/spite/THREE.MeshLine/issues/123

The fix is rather simple, adding the `#include <common>` line to the top of the vertex shader solves the issue. Even if no issue ever was, I don't think this introduces anything but benefits? Correct me if I am wrong. At least it solves our problem.

Currently we are working around this with the following code:

```
const lineMat = new MeshLineMaterial({
            useMap: false,
            color: new THREE.Color(color),
            opacity: 1,
            lineWidth: 10,
            sizeAttenuation: false,
            resolution: resolutionReference
        } as THREE.ShaderMaterialParameters & MeshLineMaterial);

lineMat.vertexShader = "#include <common>\n" + lineMat.vertexShader; // Fix weird bug with vertex shader
```

Could this finally be merged to this fork? It was seemingly never merged in the original before the project died.